### PR TITLE
- Add Include timestamp or not parameter to get camera stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist
 *.zip
 *.beta
 *.orig
+venv

--- a/octoprint_webcamSB/__init__.py
+++ b/octoprint_webcamSB/__init__.py
@@ -3,39 +3,41 @@ from __future__ import absolute_import
 
 import octoprint.plugin
 
+
 class WebcamSBPlugin(octoprint.plugin.StartupPlugin,
-               octoprint.plugin.AssetPlugin,
-               octoprint.plugin.TemplatePlugin,
-			   octoprint.plugin.SettingsPlugin):
+					 octoprint.plugin.AssetPlugin,
+					 octoprint.plugin.TemplatePlugin,
+					 octoprint.plugin.SettingsPlugin):
 
 	def on_after_startup(self):
 		self._logger.info("Sidebar Webcam LOADED");
-		orden_sidebar = self._settings.global_get(["appearance","components","order","sidebar"])
+		orden_sidebar = self._settings.global_get(["appearance", "components", "order", "sidebar"])
 		if "plugin_webcamSB" in orden_sidebar:
 			orden_sidebar.remove("plugin_webcamSB")
 		nuevo_orden = ["plugin_webcamSB"] + orden_sidebar
-		self._settings.global_set(["appearance","components","order","sidebar"],nuevo_orden)
-	
+		self._settings.global_set(["appearance", "components", "order", "sidebar"], nuevo_orden)
+
 	def on_plugin_enabled(self):
 		pass
 
-	def get_settings_defaults(self):		
-		return dict(url="",url1="",url2="",url3="",expand=1,defaultCam=1,f1x=0,f1z=0,f2x=0,f2z=0,rot1=0,rot2=0,name="1",name1="2",name2="3",name3="4",selector=1,asp1=1,asp2=1)
+	def get_settings_defaults(self):
+		return dict(url="", url1="", url2="", url3="", expand=1, defaultCam=1, f1x=0, f1z=0, f2x=0, f2z=0, rot1=0,
+					rot2=0, name="1", name1="2", name2="3", name3="4", selector=1, asp1=1, asp2=1, its1=1, its2=1)
 
 	def get_assets(self):
 		return dict(
 			js=["js/webcamsb.js"],
 			css=["css/webcamsb.css"]
 		)
-		
+
 	def get_template_configs(self):
 		return [
 			dict(type="sidebar", name="Stream", template="webcamsb_sidebar.jinja2", custom_bindings=False),
 			dict(type="settings", name="Sidebar Webcam", template="webcamsb_settings.jinja2", custom_bindings=False)
 		]
-	
+
 	def get_template_vars(self):
-		return dict(webcamStream=self._settings.global_get(["webcam","stream"]))
+		return dict(webcamStream=self._settings.global_get(["webcam", "stream"]))
 
 	##~~ Softwareupdate hook
 
@@ -63,10 +65,11 @@ class WebcamSBPlugin(octoprint.plugin.StartupPlugin,
 __plugin_name__ = "Sidebar Webcam"
 __plugin_pythoncompat__ = ">=2.7,<4"
 
+
 def __plugin_load__():
 	# Change suggested by jneilliii
 	# global __plugin_settings_overlay__
-	#__plugin_settings_overlay__ = dict(appearance=dict(components=dict(order=dict(sidebar=["plugin_webcamSB"]))))
+	# __plugin_settings_overlay__ = dict(appearance=dict(components=dict(order=dict(sidebar=["plugin_webcamSB"]))))
 	#
 	global __plugin_implementation__
 	__plugin_implementation__ = WebcamSBPlugin()
@@ -74,4 +77,3 @@ def __plugin_load__():
 	__plugin_hooks__ = {
 		"octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information
 	}
-

--- a/octoprint_webcamSB/static/js/webcamsb.js
+++ b/octoprint_webcamSB/static/js/webcamsb.js
@@ -7,15 +7,16 @@
 $(function() {
     function WebcamSBViewModel(parameters) {
 		var self = this;
-		self.settings = parameters[0];	
+		self.settings = parameters[0];
 		self.expanded_cam = 0; //Change suggested by jneilliii to avoid conflicts with his widescreen plugin
-		self.onBeforeBinding = function() {	
+		self.onBeforeBinding = function() {
 			var st = self.settings.settings.plugins.webcamSB;
 			self.streams = [st.url(),st.url1(),st.url2(),st.url3()];
 			self.names = [st.name(),st.name1(),st.name2(),st.name3()];
 			self.flips = [st.f1x(),st.f1z(),st.f2x(),st.f2z()];
 			self.rotates = [st.rot1(),st.rot2()];
 			self.aspect = [st.asp1(),st.asp2()];
+			self.includeTimeStamps = [st.its1(),st.its2()];
 			self.selector = st.selector();
 			var num_cams = 0;
 			var def_cam = self.settings.settings.plugins.webcamSB.defaultCam();
@@ -34,8 +35,8 @@ $(function() {
 					}
 					num_cams++;
 				}
-			}	
-			
+			}
+
 			if (num_cams > 1) $('#wcsb_bot').append(botones);
 			if (num_cams == 0) {
 				$('#webcamsb').html("<p style='font-size:0.9em;text-align:center'>Stream not set</p>"); return;
@@ -43,7 +44,7 @@ $(function() {
 			var x = 3;
 			while (x >= 0) {
 				if (def_cam == x+1 && self.streams[x] == "") {
-					def_cam--; x--; continue; 
+					def_cam--; x--; continue;
 				} else {
 					self.wcsb_cargaCam(def_cam-1);
 					break;
@@ -56,13 +57,18 @@ $(function() {
 			$("#wcsb_bt_"+cual+"").addClass("btn-primary");
 			var str = self.streams[cual];
 			var lacam = $("#sidewebcam");
-			str += "?" + new Date().getTime();
-			lacam.attr("src", str);	
-			var fx = 1; var fy = 1; var x = 0; 
+			let currentTime = new Date().getTime();
+			let includeTimeStamp = self.includeTimeStamps[cual];
+			if (includeTimeStamp == undefined || includeTimeStamp === 1) {
+			    str += "?" + currentTime;
+            }
+
+			lacam.attr("src", str);
+			var fx = 1; var fy = 1; var x = 0;
 			if (cual <= 1) {
 				if (cual == 1) x = 2;
 				if (self.flips[x+0] == 1) fx = -1;
-				if (self.flips[x+1] == 1) fy = -1; 
+				if (self.flips[x+1] == 1) fy = -1;
 			};
 			var rotation = 0;
  			if (self.rotates[cual] != undefined) rotation = self.rotates[cual];
@@ -71,9 +77,9 @@ $(function() {
 			if (rotation != 0) {
 				imc_w = max_h+"px";
 				if (self.aspect[cual] == 2) imc_h = Math.floor(max_h*(3/4))+"px";
-				if (self.aspect[cual] == 1) imc_h = Math.floor(max_h*(9/16))+"px";	
+				if (self.aspect[cual] == 1) imc_h = Math.floor(max_h*(9/16))+"px";
 				is_rot = self.aspect[cual];
-			} 
+			}
 			window.localStorage.setItem('wcsb_im_h', imc_h);
 			window.localStorage.setItem('wcsb_im_w', imc_w);
 			window.localStorage.setItem('wcsb_im_rot', is_rot);
@@ -83,14 +89,14 @@ $(function() {
 		self.wcsbPOC = function() {
 			var tamh = 'auto'; var tamw = '100%';
 			if (self.settings.settings.plugins.webcamSB.expand() == 1) {
-				if (self.expanded_cam > 0) { 
-					tamw = window.localStorage.getItem('wcsb_im_w'); tamh = window.localStorage.getItem('wcsb_im_h'); 
+				if (self.expanded_cam > 0) {
+					tamw = window.localStorage.getItem('wcsb_im_w'); tamh = window.localStorage.getItem('wcsb_im_h');
 					$('#wcsb_bk').remove();
 					$('#wcsb_imc').css({"position":"relative","top":0,"left":0,"width":"100%","height":"100%"});
 					$('#wcsb_imc').css({"height":tamw});
 					self.expanded_cam = 0;
 				} else {
-					tamw = 'auto'; tamh = '100%'; 
+					tamw = 'auto'; tamh = '100%';
 					var esrot = window.localStorage.getItem('wcsb_im_rot');
 					$('#webcamsb').append('<div id="wcsb_bk"></div>');
 					$('#wcsb_bk').css({"opacity":0.7,"position":"fixed","background-color":"#000","left":0,"top":0,"width":"100%","height":"100%","z-index":9});
@@ -101,8 +107,8 @@ $(function() {
 			}
 		}
 		self.onAfterBinding = function() {
-			$('#sidebar_plugin_webcamSB_wrapper .accordion-heading a').prepend('<i class="fa icon-black fa-camera"/>');	
-        };			
+			$('#sidebar_plugin_webcamSB_wrapper .accordion-heading a').prepend('<i class="fa icon-black fa-camera"/>');
+        };
     };
     OCTOPRINT_VIEWMODELS.push({
         construct: WebcamSBViewModel,

--- a/octoprint_webcamSB/templates/webcamsb_settings.jinja2
+++ b/octoprint_webcamSB/templates/webcamsb_settings.jinja2
@@ -30,6 +30,12 @@
 							<option value="2">4:3</option>
 						</select>
 					</div>
+                    <div>Include TimeStamp</br>
+						<select class="wbsc_s" data-bind="value: settings.plugins.webcamSB.its1"/>
+							<option value="0">NO</option>
+							<option value="1">YES</option>
+						</select>
+					</div>
 				</div>
 			</div>
 			<div class="controls">
@@ -59,6 +65,12 @@
 						<select class="wbsc_s" data-bind="value: settings.plugins.webcamSB.asp2"/>
 							<option value="1">16:9</option>
 							<option value="2">4:3</option>
+						</select>
+					</div>
+                    <div>Include TimeStamp</br>
+						<select class="wbsc_s" data-bind="value: settings.plugins.webcamSB.its2"/>
+							<option value="0">NO</option>
+							<option value="1">YES</option>
 						</select>
 					</div>
 				</div>
@@ -92,7 +104,7 @@
 					<option value="1">Buttons</option>
 					<option value="0">List</option>
 				</select>
-			</div-->			
+			</div-->
 		</div>
 		Please "SAVE" and refresh your browser with CTRL+F5 after changing your settings.
 </form>


### PR DESCRIPTION
I found a problem with my very old wifi camera. If the request gets an image have ?{timestamp}, it will stop working.
This PR can make your plugin work with some wifi camera. Now we will have the option to include a timestamp or not, default on.
